### PR TITLE
[codegen] Support generic `object` property

### DIFF
--- a/codegen/src/codegen.ts
+++ b/codegen/src/codegen.ts
@@ -77,6 +77,7 @@ export class Codegen {
 `#ifndef RPCINTERFACE_H
 #define RPCINTERFACE_H\n
 #include <jsonrpccxx/server.hpp>
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>\n
@@ -215,6 +216,10 @@ using namespace jsonrpccxx;\n`;
             if (item.properties) {
               tsType = this.getTypeName(name, suffix);
               cppType = `${prefix ?? ''}${tsType}`;
+            } else if (item.additionalProperties) {
+              const {cpp, ts} = this.getType(name, item.additionalProperties, suffix);
+              tsType = `Record<string, ${ts}>`;
+              cppType = `map<string, ${cpp}>`;
             } else {
               console.error('unknown type:', item.type);
             }


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Generate generic C++ `map` and TS `Record` for properties with type `object` and accepting `additionalProperties`.
For example the following schema:
``` yml
Device:
  type: object
  properties:
    name:
      type: string
    attributes:
      type: object
      additionalProperties:
        type: string
  required:
    - name
    - attributes
```
Results in the following interfaces for C++ and TS respectively:
``` c++
struct Device {
  string name;
  map<string, string> attributes;
};
```
``` ts
export interface Device {
    name: string,
    attributes: Record<string, string>,
}
```

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
