### PR TITLE
Export RPC API version

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -96,6 +96,17 @@ jobs:
           name: codegen-rpc-interfaces
           path: generated
 
+      - name: Check release version tag
+        run: |
+          version=$(grep -oP 'RPC_API_VERSION\s*=\s*"\K[^"]+' RpcInterface.h)
+          tag=${{ github.event.release.tag_name }}
+          tag="${tag#v}"
+          if [ "$tag" != "$version" ]; then
+            echo "Release version does not match the version in generated interfaces. Update csolution-openapi.yml"
+            exit 1
+          fi
+        working-directory: generated
+
       - name: ZIP generated files
         run: zip -r csolution-rpc.zip RpcInterface.h rpc-interface.ts
         working-directory: generated

--- a/api/csolution-openapi.yml
+++ b/api/csolution-openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: csolution rpc
-  version: 0.0.3
+  version: 0.0.4
   description: Specification of remote procedure call methods for CMSIS csolution integration
   license:
     name: Apache 2.0
@@ -784,6 +784,9 @@ components:
             version:
               type: string
               description: Tool version
+            apiVersion:
+              type: string
+              description: API version
     GetVersionResponse:
       allOf:
         - $ref: '#/x-jsonrpc-envelope-response'


### PR DESCRIPTION

## Changes
<!-- List the changes this PR introduces -->
- Export `RPC_API_VERSION` into generated interfaces
- Add `apiVersion` field in `GetVersion` method response
- Extend release workflow to check whether tag and generated version match

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
